### PR TITLE
feat: add integration with fancy-holograms (#8)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,11 +16,18 @@ repositories {
         name = "sonatype"
         url = "https://oss.sonatype.org/content/groups/public/"
     }
+    maven {
+        name = "fancyinnovations"
+        url = "https://repo.fancyinnovations.com/releases"
+    }
 }
 
 dependencies {
     compileOnly("org.projectlombok:lombok:1.18.38")
     compileOnly("io.papermc.paper:paper-api:1.21.5-R0.1-SNAPSHOT")
+
+    // Integration with https://hangar.papermc.io/Oliver/FancyHolograms
+    compileOnly("de.oliver:FancyHolograms:2.7.0")
 
     annotationProcessor("org.projectlombok:lombok:1.18.38")
 

--- a/src/main/java/com/github/kapitanfloww/jump/holograms/JumpHologramManager.java
+++ b/src/main/java/com/github/kapitanfloww/jump/holograms/JumpHologramManager.java
@@ -1,0 +1,74 @@
+package com.github.kapitanfloww.jump.holograms;
+
+import com.github.kapitanfloww.jump.model.Jump;
+import com.github.kapitanfloww.jump.service.JumpLocationService;
+import de.oliver.fancyholograms.api.FancyHologramsPlugin;
+import de.oliver.fancyholograms.api.HologramManager;
+import de.oliver.fancyholograms.api.data.TextHologramData;
+import de.oliver.fancyholograms.api.hologram.Hologram;
+import lombok.extern.java.Log;
+import org.bukkit.Color;
+import org.bukkit.entity.Display;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+@Log
+public class JumpHologramManager {
+
+    private static final String NAME_PATTERN = "floww_jump_%s";
+
+    private final JumpLocationService locationService;
+    private final HologramManager hologramManager;
+
+    public JumpHologramManager(JumpLocationService locationService, HologramManager hologramManager) {
+        this.locationService = Objects.requireNonNull(locationService);
+        this.hologramManager = Objects.requireNonNull(hologramManager);
+    }
+
+    public void createHologram(Jump jump) {
+        // Check if hologram already exist
+        if (getHologram(jump).isPresent()) {
+            throw new IllegalArgumentException("Hologram with that name already exist!");
+        }
+        final var location = locationService.toLocation(jump.getStart()).add(0.5, 1.5, 0.5);
+        final var hologramData = new TextHologramData(NAME_PATTERN.formatted(jump.getName()), location);
+        hologramData.setBackground(Color.fromBGR(100, 255, 79));
+        hologramData.setBillboard(Display.Billboard.CENTER);
+        hologramData.removeLine(0);
+        hologramData.setText(List.of("~~ Welcome to Jump: " + jump.getName() + " ~~"));
+
+        final var manager = FancyHologramsPlugin.get().getHologramManager();
+        final var hologram = manager.create(hologramData);
+
+        manager.addHologram(hologram);
+        log.info("Hologram %s created at [%s, %s, %s]".formatted(NAME_PATTERN.formatted(jump.getName()), location.getX(), location.getY(), location.getZ()));
+    }
+
+    public void removeHologram(Jump jump) {
+        final var hologram = getHologram(jump);
+        hologram.ifPresent(hologramManager::removeHologram);
+        log.info("Hologram %s removed".formatted(NAME_PATTERN.formatted(jump.getName())));
+    }
+
+    public void moveHologram(Jump jump) {
+        final var optionalHologram = getHologram(jump);
+        if (optionalHologram.isEmpty()) {
+            throw new IllegalArgumentException("Hologram for jump %s does not exist".formatted(jump.getName()));
+        }
+
+        final var hologram = optionalHologram.get();
+        final var hologramData = hologram.getData();
+
+        final var location = locationService.toLocation(jump.getStart()).add(0.5, 1.5, 0.5);
+        hologramData.setLocation(location);
+
+        hologram.forceUpdate();
+        hologram.queueUpdate();
+    }
+
+    public Optional<Hologram> getHologram(Jump jump) {
+        return hologramManager.getHologram(NAME_PATTERN.formatted(jump.getName()));
+    }
+}

--- a/src/main/java/com/github/kapitanfloww/jump/service/JumpService.java
+++ b/src/main/java/com/github/kapitanfloww/jump/service/JumpService.java
@@ -22,7 +22,7 @@ public class JumpService {
         this.repository = Objects.requireNonNull(repository);
     }
 
-    public void createJump(String jumpName, Block start) {
+    public Jump createJump(String jumpName, Block start) {
         // Check if jump with the name exists
         if (findJump(jumpName).isPresent()) {
             throw new IllegalArgumentException("Jump with name \"%s\" already exists".formatted(jumpName));
@@ -36,9 +36,10 @@ public class JumpService {
 
         repository.save(jump);
         log.info("Created jump %s".formatted(jump));
+        return jump;
     }
 
-    public void addLocationToJump(String jumpName, JumpLocationType type, Block location) {
+    public Jump addLocationToJump(String jumpName, JumpLocationType type, Block location) {
         final var jump = getJump(jumpName);
         final var newLocation = JumpLocation.fromBlock(location);
         switch (type) {
@@ -49,6 +50,7 @@ public class JumpService {
         }
         log.info("Added location %s to jump \"%s\"".formatted(type, jump));
         repository.merge(jump);
+        return jump;
     }
 
     public void removeCheckpointForJump(String jumpName, Block location) {
@@ -79,9 +81,10 @@ public class JumpService {
         return repository.findAll();
     }
 
-    public void deleteJump(String jumpName) {
+    public Jump deleteJump(String jumpName) {
         final var jump = getJump(jumpName);
         repository.delete(jump);
+        return jump;
     }
 
     public List<JumpLocation> getCheckpointsForJump(String jumpName) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -7,6 +7,9 @@ load: STARTUP
 authors: [ Kapitan_Floww ]
 description: Plugin to create parcours for Paper servers
 website: https://github.com/KapitanFloww/floww-jump
+softdepend: [FancyHolograms]
 commands:
   jump:
     description: "Manage Jumps"
+  checkpoint:
+    description: "Reset to last checkpoint"


### PR DESCRIPTION
This is the first iteration of integration with [FancyHolograms](https://hangar.papermc.io/Oliver/FancyHolograms).
This will create a hologram at each jump start location with the name of the jump.

Holograms will get removed if their jump is getting removed.

Additionally, holograms may be re-created by execution `/jump holograms reload`.